### PR TITLE
Fix SQL injection vulnerability in adm_config_report.php

### DIFF
--- a/adm_config_report.php
+++ b/adm_config_report.php
@@ -245,14 +245,18 @@ while( $row = db_fetch_array( $t_result ) ) {
 
 # Build filter's where clause
 $t_where = '';
+$t_param = array();
 if( $t_filter_user_value != META_FILTER_NONE ) {
-	$t_where .= " AND user_id = $t_filter_user_value ";
+	$t_where .= " AND user_id = " . db_param();
+	$t_param[] = $t_filter_user_value;
 }
 if( $t_filter_project_value != META_FILTER_NONE ) {
-	$t_where .= " AND project_id = $t_filter_project_value ";
+	$t_where .= " AND project_id = " . db_param();
+	$t_param[] = $t_filter_project_value;
 }
 if( $t_filter_config_value != META_FILTER_NONE ) {
-	$t_where .= " AND config_id = '$t_filter_config_value' ";
+	$t_where .= " AND config_id = " . db_param();
+	$t_param[] = $t_filter_config_value;
 }
 if( $t_where != '' ) {
 	$t_where = " WHERE 1=1 " . $t_where;
@@ -262,7 +266,7 @@ $query = "SELECT config_id, user_id, project_id, type, value, access_reqd
 	FROM $t_config_table
 	$t_where
 	ORDER BY user_id, project_id, config_id ";
-$result = db_query_bound( $query );
+$result = db_query_bound( $query, $t_param );
 ?>
 
 <!-- FILTER FORM -->


### PR DESCRIPTION
Jakub Galczyk (HauntIT blog http://hauntit.blogspot.com/) reported this
issue, introduced by f8a81a33880752364ea47bdd9a987bff986c81de in
MantisBT 1.2.13.

Root cause is the use of unsanitized inlined query parameters.

Fixes #17055
